### PR TITLE
Bump gosu version which had an issue with HOME var

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -34,8 +34,8 @@ RUN set -x; \
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN set -x; \
         apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-        && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-        && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+        && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+        && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
         && gpg --verify /usr/local/bin/gosu.asc \
         && rm /usr/local/bin/gosu.asc \
         && chmod +x /usr/local/bin/gosu \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -34,8 +34,8 @@ RUN set -x; \
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN set -x; \
         apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-        && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-        && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+        && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
+        && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
         && gpg --verify /usr/local/bin/gosu.asc \
         && rm /usr/local/bin/gosu.asc \
         && chmod +x /usr/local/bin/gosu \


### PR DESCRIPTION
If one try to run this image with *docker run --rm -ti kd_odoo /bin/bash* it will successfully enter the shell but will throw the permission denied error trying to execute */root/.bashrc*.

This happens because the old gosu bin did not override the $HOME variable setting it to the path of the user's homedir we are trying to *sudo*. And by default *.bashrc* is taken from $HOME/.bashrc.

The new one fixes that.